### PR TITLE
added "release" build option to main build script

### DIFF
--- a/2build_zpython.sh
+++ b/2build_zpython.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+DEBUG=" --with-pydebug"
 SCRIPT=$(readlink -f "$0")
 SCRIPT_PATH=`dirname "$SCRIPT"`
 
@@ -8,21 +9,28 @@ export PYTHONPATH=${ZPYTHON_ROOT}/Lib:${ZPYTHON_ROOT}
 export PYTHONHOME=${ZPYTHON_ROOT}/install
 export LDFLAGS="-m64 -Wl,--no-export-dynamic -static-libgcc"
 
+if [[ "$1" == "release" ]]; then
+	DEBUG=""
+	STRIP="x86_64-nacl-strip python"
+fi
+
 ./configure \
 --host=x86_64-nacl \
 --prefix=${ZPYTHON_ROOT}/install \
 --without-threads \
 --enable-shared=no \
 --disable-shared \
---with-pydebug
+$DEBUG
 
 export HOSTPYTHON=`which python`
 export HOSTPGEN=./Parser/hostpgen
 
 make python install
 
+$STRIP
+
 echo "Creating python.tar.."
-tar cf python.tar -C install/ include/ lib/ --exclude=libpython2.7.a
+tar cf python.tar python -C install/ include/ lib/ --exclude=libpython2.7.a
 echo "Done!"
 
 


### PR DESCRIPTION
now running ./2build_zpython.sh release
will build python.tar in release mode:
- no debug build options
- main binary will be stripped

as an added bonus the binary will always be included in python.tar
