### PR TITLE
split PREFIX into PREFIX and DESTDIR

### DIFF
--- a/2build_zpython.sh
+++ b/2build_zpython.sh
@@ -16,7 +16,7 @@ fi
 
 ./configure \
 --host=x86_64-nacl \
---prefix=${ZPYTHON_ROOT}/install \
+--prefix=/ \
 --without-threads \
 --enable-shared=no \
 --disable-shared \
@@ -25,7 +25,7 @@ $DEBUG
 export HOSTPYTHON=`which python`
 export HOSTPGEN=./Parser/hostpgen
 
-make python install
+make python install DESTDIR=${ZPYTHON_ROOT}/install
 
 $STRIP
 


### PR DESCRIPTION
using a `PREFIX` that is relative to checkout tree is unwise as `PYTHONPATH` and `PYTHONHOME` will point there after compilation
all relative stuff was moved to `DESTDIR` and `PREFIX=/` now, because this where we mount our `python.tar` when executing it
